### PR TITLE
host permissions for sign in URLs with region

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "manifest": {
     "host_permissions": [
-      "https://signin.aws.amazon.com/saml"
+      "https://signin.aws.amazon.com/saml",
+      "https://*.signin.aws.amazon.com/saml"
     ],
     "browser_specific_settings": {
       "gecko": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-saml-sign-in-beautifier",
   "displayName": "AWS SAML Sign-In Beautifier",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A browser extension that enhances the AWS SAML Sign-In page, making it easier to use and visually appealing.",
   "author": "Jared Chistensen",
   "scripts": {


### PR DESCRIPTION
Recently AWS has added region in the SAML sign in URL e.g., eu-west-1.signin.aws.amazon.com/saml. 
This change allows wildcard for regions in URL